### PR TITLE
Create idiomatic canbus package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
+canbus
+=====
+
+An idiomatic, dependency-free (standard library only) Go package for working with Controller Area Network (CAN) buses.
+
+Features
+- Core CAN frame type with validation and binary marshaling helpers
+- In-memory loopback bus for testing and simulation
+- Optional Linux SocketCAN driver (linux-only) implemented via raw syscalls
+- Zero external dependencies beyond the Go standard library
+
+Quick start
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "time"
+
+    "canbus"
+)
+
+func main() {
+    bus := canbus.NewLoopbackBus()
+    a := bus.Open()
+    b := bus.Open()
+    defer a.Close()
+    defer b.Close()
+
+    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+    defer cancel()
+
+    go func() { _ = a.Send(ctx, canbus.MustFrame(0x123, []byte("hi"))) }()
+
+    f, err := b.Receive(ctx)
+    if err != nil { panic(err) }
+    fmt.Printf("ID=%03X LEN=%d DATA=%x\n", f.ID, f.Len, f.Data[:f.Len])
+}
+```
+
+Linux SocketCAN
+- Build tag: enabled automatically on linux. The `socketcan_linux.go` driver uses only `syscall` and raw syscalls.
+- Open a socket with an interface name (e.g., `can0`) using `canbus.DialSocketCAN("can0")`.
+
+License
+MIT
+
 # canbus
 A lightweight Golang library for working with CAN bus — send, receive, and parse CAN frames with ease.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ Quick start
 package main
 
 import (
-    "context"
     "fmt"
-    "time"
 
     "canbus"
 )
@@ -28,12 +26,9 @@ func main() {
     defer a.Close()
     defer b.Close()
 
-    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-    defer cancel()
+    go func() { _ = a.Send(canbus.MustFrame(0x123, []byte("hi"))) }()
 
-    go func() { _ = a.Send(ctx, canbus.MustFrame(0x123, []byte("hi"))) }()
-
-    f, err := b.Receive(ctx)
+    f, err := b.Receive()
     if err != nil { panic(err) }
     fmt.Printf("ID=%03X LEN=%d DATA=%x\n", f.ID, f.Len, f.Data[:f.Len])
 }
@@ -42,6 +37,41 @@ func main() {
 Linux SocketCAN
 - Build tag: enabled automatically on linux. The `socketcan_linux.go` driver uses only `syscall` and raw syscalls.
 - Open a socket with an interface name (e.g., `can0`) using `canbus.DialSocketCAN("can0")`.
+
+Example (Linux SocketCAN)
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "time"
+
+    "canbus"
+)
+
+func main() {
+    bus, err := canbus.DialSocketCAN("can0")
+    if err != nil { log.Fatal(err) }
+    defer bus.Close()
+
+    // Send a frame
+    if err := bus.Send(canbus.MustFrame(0x123, []byte{0xDE, 0xAD, 0xBE, 0xEF})); err != nil {
+        log.Fatal(err)
+    }
+
+    // Receive a frame (blocks)
+    go func() {
+        for {
+            f, err := bus.Receive()
+            if err != nil { log.Fatal(err) }
+            fmt.Printf("< %03X [%d] % x\n", f.ID, f.Len, f.Data[:f.Len])
+        }
+    }()
+
+    time.Sleep(2 * time.Second)
+}
+```
 
 License
 MIT

--- a/canbus/bus.go
+++ b/canbus/bus.go
@@ -1,7 +1,6 @@
 package canbus
 
 import (
-    "context"
     "errors"
 )
 
@@ -9,12 +8,11 @@ import (
 // Implementations should be safe for concurrent use by multiple goroutines.
 type Bus interface {
     // Send transmits a frame. It may block until the frame is queued or sent.
-    // Context cancellation should abort the operation and return the context error.
-    Send(ctx context.Context, frame Frame) error
+    Send(frame Frame) error
 
-    // Receive retrieves the next available frame. It should block until a frame
-    // is available or the context is cancelled.
-    Receive(ctx context.Context) (Frame, error)
+    // Receive retrieves the next available frame. It blocks until a frame
+    // is available or the bus/endpoint is closed.
+    Receive() (Frame, error)
 
     // Close releases resources. Further Send/Receive may return an error.
     Close() error

--- a/canbus/bus.go
+++ b/canbus/bus.go
@@ -1,0 +1,25 @@
+package canbus
+
+import (
+    "context"
+    "errors"
+)
+
+// Bus represents a CAN bus connection which can send and receive CAN frames.
+// Implementations should be safe for concurrent use by multiple goroutines.
+type Bus interface {
+    // Send transmits a frame. It may block until the frame is queued or sent.
+    // Context cancellation should abort the operation and return the context error.
+    Send(ctx context.Context, frame Frame) error
+
+    // Receive retrieves the next available frame. It should block until a frame
+    // is available or the context is cancelled.
+    Receive(ctx context.Context) (Frame, error)
+
+    // Close releases resources. Further Send/Receive may return an error.
+    Close() error
+}
+
+// ErrClosed indicates the bus or endpoint has been closed.
+var ErrClosed = errors.New("canbus: closed")
+

--- a/canbus/doc.go
+++ b/canbus/doc.go
@@ -1,0 +1,9 @@
+// Package canbus provides core types and utilities for working with
+// Controller Area Network (CAN) in Go without external dependencies.
+//
+// It includes:
+//   - A core Frame type with validation and binary marshaling helpers
+//   - An in-memory loopback bus for tests and simulations
+//   - A Linux SocketCAN driver (linux-only) via raw syscalls
+package canbus
+

--- a/canbus/example_test.go
+++ b/canbus/example_test.go
@@ -1,0 +1,24 @@
+package canbus
+
+import (
+    "context"
+    "fmt"
+    "time"
+)
+
+func ExampleLoopbackBus() {
+    bus := NewLoopbackBus()
+    a := bus.Open()
+    b := bus.Open()
+    defer a.Close()
+    defer b.Close()
+
+    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+    defer cancel()
+
+    go func() { _ = a.Send(ctx, MustFrame(0x123, []byte("hi"))) }()
+    f, _ := b.Receive(ctx)
+    fmt.Printf("ID=%03X LEN=%d DATA=%x\n", f.ID, f.Len, f.Data[:f.Len])
+    // Output: ID=123 LEN=2 DATA=6869
+}
+

--- a/canbus/example_test.go
+++ b/canbus/example_test.go
@@ -1,9 +1,7 @@
 package canbus
 
 import (
-    "context"
     "fmt"
-    "time"
 )
 
 func ExampleLoopbackBus() {
@@ -13,11 +11,8 @@ func ExampleLoopbackBus() {
     defer a.Close()
     defer b.Close()
 
-    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-    defer cancel()
-
-    go func() { _ = a.Send(ctx, MustFrame(0x123, []byte("hi"))) }()
-    f, _ := b.Receive(ctx)
+    go func() { _ = a.Send(MustFrame(0x123, []byte("hi"))) }()
+    f, _ := b.Receive()
     fmt.Printf("ID=%03X LEN=%d DATA=%x\n", f.ID, f.Len, f.Data[:f.Len])
     // Output: ID=123 LEN=2 DATA=6869
 }

--- a/canbus/frame.go
+++ b/canbus/frame.go
@@ -4,6 +4,7 @@ import (
     "encoding/binary"
     "errors"
     "fmt"
+    "strings"
 )
 
 // Frame represents a classical CAN (2.0A/2.0B) frame.
@@ -121,5 +122,33 @@ func (f *Frame) UnmarshalBinary(data []byte) error {
     f.Len = uint8(data[4])
     copy(f.Data[:], data[8:16])
     return f.Validate()
+}
+
+// String returns a human-friendly representation similar to candump formatting.
+// Examples:
+//   123 [2] DE AD
+//   1ABCDEFF [0]
+//   123 [4] RTR
+func (f Frame) String() string {
+    width := 3
+    if f.Extended {
+        width = 8
+    }
+    var b strings.Builder
+    fmt.Fprintf(&b, "%0*X [%d]", width, f.ID, f.Len)
+    if f.RTR {
+        b.WriteString(" RTR")
+        return b.String()
+    }
+    if f.Len > 0 {
+        b.WriteByte(' ')
+        for i := 0; i < int(f.Len); i++ {
+            if i > 0 {
+                b.WriteByte(' ')
+            }
+            fmt.Fprintf(&b, "%02X", f.Data[i])
+        }
+    }
+    return b.String()
 }
 

--- a/canbus/frame.go
+++ b/canbus/frame.go
@@ -1,0 +1,125 @@
+package canbus
+
+import (
+    "encoding/binary"
+    "errors"
+    "fmt"
+)
+
+// Frame represents a classical CAN (2.0A/2.0B) frame.
+//
+// Supported features:
+//   - Standard (11-bit) and Extended (29-bit) identifiers
+//   - Data frames and Remote Transmission Request (RTR)
+//   - Data length 0-8 bytes (classical CAN)
+//
+// Not implemented: CAN FD specific fields.
+type Frame struct {
+    ID       uint32 // 11-bit (std) or 29-bit (ext)
+    Extended bool   // true for 29-bit identifier
+    RTR      bool   // remote transmission request
+    Len      uint8  // 0..8
+    Data     [8]byte
+}
+
+// Validation limits.
+const (
+    maxStdID = 0x7FF
+    maxExtID = 0x1FFFFFFF
+)
+
+var (
+    ErrInvalidID  = errors.New("canbus: invalid identifier")
+    ErrInvalidLen = errors.New("canbus: invalid data length")
+)
+
+// Validate returns an error if the frame is not valid.
+func (f Frame) Validate() error {
+    if f.Len > 8 {
+        return ErrInvalidLen
+    }
+    if f.Extended {
+        if f.ID > maxExtID {
+            return ErrInvalidID
+        }
+    } else {
+        if f.ID > maxStdID {
+            return ErrInvalidID
+        }
+    }
+    return nil
+}
+
+// MustFrame constructs a Frame and panics if invalid. Convenience for examples.
+func MustFrame(id uint32, data []byte) Frame {
+    var f Frame
+    f.ID = id
+    if id > maxStdID {
+        f.Extended = true
+    }
+    if len(data) > 8 {
+        panic(ErrInvalidLen)
+    }
+    f.Len = uint8(len(data))
+    copy(f.Data[:], data)
+    if err := f.Validate(); err != nil {
+        panic(err)
+    }
+    return f
+}
+
+// MarshalBinary encodes the frame to the Linux SocketCAN "struct can_frame" layout
+// (16 bytes) for classical CAN. This layout is widely used and suitable for
+// capture or transport. It intentionally does not include timestamping.
+//
+// Layout (little-endian):
+//   0..3  can_id (with flags: EFF/RTR/ERR)
+//   4     can_dlc (data length code)
+//   5..7  padding (set to zero)
+//   8..15 data bytes
+func (f Frame) MarshalBinary() ([]byte, error) {
+    if err := f.Validate(); err != nil {
+        return nil, err
+    }
+    var id uint32 = f.ID
+    const (
+        canEffFlag = 0x80000000
+        canRtrFlag = 0x40000000
+    )
+    if f.Extended {
+        id |= canEffFlag
+    }
+    if f.RTR {
+        id |= canRtrFlag
+    }
+    buf := make([]byte, 16)
+    binary.LittleEndian.PutUint32(buf[0:4], id)
+    buf[4] = f.Len
+    copy(buf[8:16], f.Data[:])
+    return buf, nil
+}
+
+// UnmarshalBinary decodes a frame from the Linux SocketCAN can_frame layout.
+func (f *Frame) UnmarshalBinary(data []byte) error {
+    if len(data) < 16 {
+        return fmt.Errorf("canbus: need 16 bytes, got %d", len(data))
+    }
+    id := binary.LittleEndian.Uint32(data[0:4])
+    const (
+        canEffFlag = 0x80000000
+        canRtrFlag = 0x40000000
+        canEffMask = 0x1FFFFFFF
+        canStdMask = 0x7FF
+    )
+    f.Extended = id&canEffFlag != 0
+    f.RTR = id&canRtrFlag != 0
+    if f.Extended {
+        f.ID = id & canEffMask
+    } else {
+        f.ID = id & canStdMask
+    }
+    f.Len = uint8(data[4])
+    copy(f.Data[:], data[8:16])
+    return f.Validate()
+}
+

--- a/canbus/frame_test.go
+++ b/canbus/frame_test.go
@@ -43,6 +43,9 @@ func TestExtendedAndRTR(t *testing.T) {
     if g.ID != f.ID || !g.Extended || !g.RTR {
         t.Fatalf("flags lost: got %+v", g)
     }
+    if got := g.String(); got != "1ABCDEFF [0] RTR" {
+        t.Fatalf("string mismatch: %q", got)
+    }
 }
 
 func TestLoopbackBus(t *testing.T) {
@@ -66,6 +69,9 @@ func TestLoopbackBus(t *testing.T) {
     }
     if err := <-done; err != nil {
         t.Fatalf("send: %v", err)
+    }
+    if got.String() != "321 [5] 68 65 6C 6C 6F" {
+        t.Fatalf("string: got %q", got.String())
     }
 }
 

--- a/canbus/frame_test.go
+++ b/canbus/frame_test.go
@@ -2,9 +2,7 @@ package canbus
 
 import (
     "bytes"
-    "context"
     "testing"
-    "time"
 )
 
 func TestFrameValidateAndBinary(t *testing.T) {
@@ -54,15 +52,12 @@ func TestLoopbackBus(t *testing.T) {
     defer a.Close()
     defer b.Close()
 
-    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-    defer cancel()
-
     send := MustFrame(0x321, []byte("hello"))
 
     done := make(chan error, 1)
-    go func() { done <- a.Send(ctx, send) }()
+    go func() { done <- a.Send(send) }()
 
-    got, err := b.Receive(ctx)
+    got, err := b.Receive()
     if err != nil {
         t.Fatalf("receive: %v", err)
     }

--- a/canbus/frame_test.go
+++ b/canbus/frame_test.go
@@ -1,0 +1,76 @@
+package canbus
+
+import (
+    "bytes"
+    "context"
+    "testing"
+    "time"
+)
+
+func TestFrameValidateAndBinary(t *testing.T) {
+    f := MustFrame(0x123, []byte{1, 2, 3, 4})
+    if err := f.Validate(); err != nil {
+        t.Fatalf("validate: %v", err)
+    }
+    b, err := f.MarshalBinary()
+    if err != nil {
+        t.Fatalf("marshal: %v", err)
+    }
+    var g Frame
+    if err := g.UnmarshalBinary(b); err != nil {
+        t.Fatalf("unmarshal: %v", err)
+    }
+    if g != f {
+        t.Fatalf("roundtrip mismatch: got %+v want %+v", g, f)
+    }
+}
+
+func TestExtendedAndRTR(t *testing.T) {
+    var f Frame
+    f.ID = 0x1ABCDEFF
+    f.Extended = true
+    f.RTR = true
+    f.Len = 0
+    if err := f.Validate(); err != nil {
+        t.Fatalf("validate: %v", err)
+    }
+    b, err := f.MarshalBinary()
+    if err != nil {
+        t.Fatalf("marshal: %v", err)
+    }
+    var g Frame
+    if err := g.UnmarshalBinary(b); err != nil {
+        t.Fatalf("unmarshal: %v", err)
+    }
+    if g.ID != f.ID || !g.Extended || !g.RTR {
+        t.Fatalf("flags lost: got %+v", g)
+    }
+}
+
+func TestLoopbackBus(t *testing.T) {
+    bus := NewLoopbackBus()
+    a := bus.Open()
+    b := bus.Open()
+    defer a.Close()
+    defer b.Close()
+
+    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+    defer cancel()
+
+    send := MustFrame(0x321, []byte("hello"))
+
+    done := make(chan error, 1)
+    go func() { done <- a.Send(ctx, send) }()
+
+    got, err := b.Receive(ctx)
+    if err != nil {
+        t.Fatalf("receive: %v", err)
+    }
+    if got.ID != send.ID || got.Len != send.Len || !bytes.Equal(got.Data[:got.Len], send.Data[:send.Len]) {
+        t.Fatalf("mismatch: got %+v want %+v", got, send)
+    }
+    if err := <-done; err != nil {
+        t.Fatalf("send: %v", err)
+    }
+}
+

--- a/canbus/loopback.go
+++ b/canbus/loopback.go
@@ -1,0 +1,138 @@
+package canbus
+
+import (
+    "context"
+    "sync"
+)
+
+// LoopbackBus is an in-memory CAN bus for tests and simulations.
+// Multiple endpoints opened from the same bus can exchange frames.
+type LoopbackBus struct {
+    mu        sync.RWMutex
+    closed    bool
+    endpoints map[*loopEndpoint]struct{}
+}
+
+// NewLoopbackBus creates a new loopback bus.
+func NewLoopbackBus() *LoopbackBus {
+    return &LoopbackBus{endpoints: make(map[*loopEndpoint]struct{})}
+}
+
+// Open creates a new endpoint attached to the bus.
+func (b *LoopbackBus) Open() Bus {
+    ep := &loopEndpoint{
+        bus:    b,
+        ch:     make(chan Frame, 64),
+        closed: make(chan struct{}),
+    }
+    b.mu.Lock()
+    if b.closed {
+        b.mu.Unlock()
+        close(ep.closed)
+        return ep
+    }
+    b.endpoints[ep] = struct{}{}
+    b.mu.Unlock()
+    return ep
+}
+
+// Close closes the bus and detaches all endpoints.
+func (b *LoopbackBus) Close() error {
+    b.mu.Lock()
+    if b.closed {
+        b.mu.Unlock()
+        return nil
+    }
+    b.closed = true
+    for ep := range b.endpoints {
+        ep.closeNoLock()
+    }
+    b.endpoints = nil
+    b.mu.Unlock()
+    return nil
+}
+
+type loopEndpoint struct {
+    bus    *LoopbackBus
+    ch     chan Frame
+    mu     sync.Mutex
+    dead   bool
+    closed chan struct{}
+}
+
+// Send broadcasts the frame to all other endpoints on the same bus.
+func (e *loopEndpoint) Send(ctx context.Context, frame Frame) error {
+    if err := frame.Validate(); err != nil {
+        return err
+    }
+    e.mu.Lock()
+    if e.dead {
+        e.mu.Unlock()
+        return ErrClosed
+    }
+    e.mu.Unlock()
+    // Snapshot endpoints under bus lock to avoid holding while sending.
+    e.bus.mu.RLock()
+    if e.bus.closed {
+        e.bus.mu.RUnlock()
+        return ErrClosed
+    }
+    targets := make([]*loopEndpoint, 0, len(e.bus.endpoints))
+    for ep := range e.bus.endpoints {
+        if ep != e {
+            targets = append(targets, ep)
+        }
+    }
+    e.bus.mu.RUnlock()
+
+    // Deliver to targets honoring context cancellation.
+    for _, t := range targets {
+        select {
+        case t.ch <- frame:
+        case <-t.closed:
+            // drop
+        case <-ctx.Done():
+            return ctx.Err()
+        }
+    }
+    return nil
+}
+
+// Receive waits for the next frame.
+func (e *loopEndpoint) Receive(ctx context.Context) (Frame, error) {
+    select {
+    case f, ok := <-e.ch:
+        if !ok {
+            return Frame{}, ErrClosed
+        }
+        return f, nil
+    case <-e.closed:
+        return Frame{}, ErrClosed
+    case <-ctx.Done():
+        return Frame{}, ctx.Err()
+    }
+}
+
+// Close detaches endpoint from bus and closes its channel.
+func (e *loopEndpoint) Close() error {
+    e.bus.mu.Lock()
+    e.closeNoLock()
+    e.bus.mu.Unlock()
+    return nil
+}
+
+func (e *loopEndpoint) closeNoLock() {
+    e.mu.Lock()
+    if e.dead {
+        e.mu.Unlock()
+        return
+    }
+    e.dead = true
+    close(e.closed)
+    close(e.ch)
+    if e.bus.endpoints != nil {
+        delete(e.bus.endpoints, e)
+    }
+    e.mu.Unlock()
+}
+

--- a/canbus/socketcan_linux.go
+++ b/canbus/socketcan_linux.go
@@ -1,0 +1,185 @@
+//go:build linux
+
+package canbus
+
+import (
+    "context"
+    "errors"
+    "net"
+    "os"
+    "syscall"
+    "time"
+    "unsafe"
+)
+
+// socketCAN implements Bus over Linux SocketCAN using raw syscalls only.
+type socketCAN struct {
+    fd     int
+    file   *os.File
+    closed chan struct{}
+}
+
+// DialSocketCAN opens a raw CAN socket bound to the given interface name (e.g., "can0").
+func DialSocketCAN(iface string) (Bus, error) {
+    // Create socket: AF_CAN, SOCK_RAW, CAN_RAW (protocol 1)
+    const AF_CAN = 29
+    const CAN_RAW = 1
+    fd, err := syscall.Socket(AF_CAN, syscall.SOCK_RAW, CAN_RAW)
+    if err != nil {
+        return nil, err
+    }
+
+    // Query interface index via net.InterfaceByName
+    netIf, err := net.InterfaceByName(iface)
+    if err != nil {
+        syscall.Close(fd)
+        return nil, err
+    }
+
+    // Bind to interface
+    // struct sockaddr_can { sa_family_t can_family; int can_ifindex; union { ... } addr; };
+    // We provide a compatible memory layout via unsafe and call bind(2) directly.
+    type sockaddrCAN struct {
+        Family  uint16
+        _pad    uint16
+        Ifindex int32
+        Addr    [8]byte
+    }
+    sa := sockaddrCAN{Family: AF_CAN, Ifindex: int32(netIf.Index)}
+    _, _, e := syscall.Syscall(syscall.SYS_BIND, uintptr(fd), uintptr(unsafe.Pointer(&sa)), unsafe.Sizeof(sa))
+    if e != 0 {
+        syscall.Close(fd)
+        return nil, e
+    }
+
+    // Set non-blocking mode for context-aware operations
+    if err := syscall.SetNonblock(fd, true); err != nil {
+        syscall.Close(fd)
+        return nil, err
+    }
+
+    f := os.NewFile(uintptr(fd), "socketcan")
+    return &socketCAN{fd: fd, file: f, closed: make(chan struct{})}, nil
+}
+
+func (s *socketCAN) Close() error {
+    select {
+    case <-s.closed:
+        return nil
+    default:
+    }
+    close(s.closed)
+    // Closing file also closes the fd
+    return s.file.Close()
+}
+
+// Send writes one frame using the Linux can_frame binary layout.
+func (s *socketCAN) Send(ctx context.Context, frame Frame) error {
+    if err := frame.Validate(); err != nil {
+        return err
+    }
+    buf, err := frame.MarshalBinary()
+    if err != nil {
+        return err
+    }
+    for {
+        // Try write
+        n, werr := syscall.Write(s.fd, buf)
+        if werr == nil {
+            if n != len(buf) {
+                return errors.New("canbus: short write")
+            }
+            return nil
+        }
+        if werr == syscall.EAGAIN || werr == syscall.EWOULDBLOCK {
+            // Wait for fd to be writable or ctx canceled
+            if err := s.waitWritable(ctx); err != nil {
+                return err
+            }
+            continue
+        }
+        return werr
+    }
+}
+
+// Receive reads one frame (blocking respecting context).
+func (s *socketCAN) Receive(ctx context.Context) (Frame, error) {
+    var f Frame
+    buf := make([]byte, 16)
+    for {
+        n, rerr := syscall.Read(s.fd, buf)
+        if rerr == nil {
+            if n != len(buf) {
+                return Frame{}, errors.New("canbus: short read")
+            }
+            if err := f.UnmarshalBinary(buf); err != nil {
+                return Frame{}, err
+            }
+            return f, nil
+        }
+        if rerr == syscall.EAGAIN || rerr == syscall.EWOULDBLOCK {
+            if err := s.waitReadable(ctx); err != nil {
+                return Frame{}, err
+            }
+            continue
+        }
+        return Frame{}, rerr
+    }
+}
+
+func (s *socketCAN) waitReadable(ctx context.Context) error {
+    return s.wait(ctx, true, false)
+}
+
+func (s *socketCAN) waitWritable(ctx context.Context) error {
+    return s.wait(ctx, false, true)
+}
+
+func (s *socketCAN) wait(ctx context.Context, r, w bool) error {
+    // Use ppoll via Select with timeout from context. Fallback to small sleeps for simplicity.
+    for {
+        // Determine timeout from context
+        var timeout *syscall.Timeval
+        if deadline, ok := ctx.Deadline(); ok {
+            d := time.Until(deadline)
+            if d <= 0 {
+                return ctx.Err()
+            }
+            timeout = &syscall.Timeval{Sec: int64(d / time.Second), Usec: int64((d % time.Second) / time.Microsecond)}
+        } else {
+            // Small backoff to avoid busy loop if no deadline
+            timeout = &syscall.Timeval{Sec: 0, Usec: 50_000}
+        }
+
+        var readfds, writefds syscall.FdSet
+        if r {
+            fdSetAdd(&readfds, s.fd)
+        }
+        if w {
+            fdSetAdd(&writefds, s.fd)
+        }
+        // nfds is highest fd + 1
+        nfds := s.fd + 1
+        _, err := syscall.Select(nfds, &readfds, &writefds, nil, timeout)
+        if err == nil {
+            // Ready (or timeout without error). If timeout and not ready, check context.
+            select {
+            case <-ctx.Done():
+                return ctx.Err()
+            default:
+                return nil
+            }
+        }
+        if err == syscall.EINTR {
+            // retry
+            continue
+        }
+        return err
+    }
+}
+
+// Helpers for FD sets since x/sys is not allowed.
+func fdSetAdd(set *syscall.FdSet, fd int) {
+    set.Bits[fd/64] |= int64(1) << (uint(fd) % 64)
+}
+

--- a/canbus/socketcan_linux.go
+++ b/canbus/socketcan_linux.go
@@ -3,12 +3,10 @@
 package canbus
 
 import (
-    "context"
     "errors"
     "net"
     "os"
     "syscall"
-    "time"
     "unsafe"
 )
 
@@ -74,7 +72,7 @@ func (s *socketCAN) Close() error {
 }
 
 // Send writes one frame using the Linux can_frame binary layout.
-func (s *socketCAN) Send(ctx context.Context, frame Frame) error {
+func (s *socketCAN) Send(frame Frame) error {
     if err := frame.Validate(); err != nil {
         return err
     }
@@ -92,10 +90,8 @@ func (s *socketCAN) Send(ctx context.Context, frame Frame) error {
             return nil
         }
         if werr == syscall.EAGAIN || werr == syscall.EWOULDBLOCK {
-            // Wait for fd to be writable or ctx canceled
-            if err := s.waitWritable(ctx); err != nil {
-                return err
-            }
+            // Busy-wait with small yield
+            syscall.Select(0, nil, nil, nil, &syscall.Timeval{Usec: 1000})
             continue
         }
         return werr
@@ -103,7 +99,7 @@ func (s *socketCAN) Send(ctx context.Context, frame Frame) error {
 }
 
 // Receive reads one frame (blocking respecting context).
-func (s *socketCAN) Receive(ctx context.Context) (Frame, error) {
+func (s *socketCAN) Receive() (Frame, error) {
     var f Frame
     buf := make([]byte, 16)
     for {
@@ -118,63 +114,10 @@ func (s *socketCAN) Receive(ctx context.Context) (Frame, error) {
             return f, nil
         }
         if rerr == syscall.EAGAIN || rerr == syscall.EWOULDBLOCK {
-            if err := s.waitReadable(ctx); err != nil {
-                return Frame{}, err
-            }
+            syscall.Select(0, nil, nil, nil, &syscall.Timeval{Usec: 1000})
             continue
         }
         return Frame{}, rerr
-    }
-}
-
-func (s *socketCAN) waitReadable(ctx context.Context) error {
-    return s.wait(ctx, true, false)
-}
-
-func (s *socketCAN) waitWritable(ctx context.Context) error {
-    return s.wait(ctx, false, true)
-}
-
-func (s *socketCAN) wait(ctx context.Context, r, w bool) error {
-    // Use ppoll via Select with timeout from context. Fallback to small sleeps for simplicity.
-    for {
-        // Determine timeout from context
-        var timeout *syscall.Timeval
-        if deadline, ok := ctx.Deadline(); ok {
-            d := time.Until(deadline)
-            if d <= 0 {
-                return ctx.Err()
-            }
-            timeout = &syscall.Timeval{Sec: int64(d / time.Second), Usec: int64((d % time.Second) / time.Microsecond)}
-        } else {
-            // Small backoff to avoid busy loop if no deadline
-            timeout = &syscall.Timeval{Sec: 0, Usec: 50_000}
-        }
-
-        var readfds, writefds syscall.FdSet
-        if r {
-            fdSetAdd(&readfds, s.fd)
-        }
-        if w {
-            fdSetAdd(&writefds, s.fd)
-        }
-        // nfds is highest fd + 1
-        nfds := s.fd + 1
-        _, err := syscall.Select(nfds, &readfds, &writefds, nil, timeout)
-        if err == nil {
-            // Ready (or timeout without error). If timeout and not ready, check context.
-            select {
-            case <-ctx.Done():
-                return ctx.Err()
-            default:
-                return nil
-            }
-        }
-        if err == syscall.EINTR {
-            // retry
-            continue
-        }
-        return err
     }
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+module canbus
+
+go 1.22
+


### PR DESCRIPTION
Introduce a new `canbus` package with core types, an in-memory bus, and a Linux SocketCAN driver, using only the standard library.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c059a04-4f73-43ef-ac92-9d730a9c233f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c059a04-4f73-43ef-ac92-9d730a9c233f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

