### PR TITLE
Expand canbus library for CANopen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Features
 - Optional Linux SocketCAN driver (linux-only) implemented via raw syscalls
 - Zero external dependencies beyond the Go standard library
 
+- CANopen helpers (new)
+  - COB-ID helpers and function code mapping
+  - NMT build/parse utilities
+  - Heartbeat (NMT error control) build/parse
+  - EMCY encode/decode
+  - SDO expedited helpers and a minimal synchronous SDO client
+
 Quick start
 ```go
 package main
@@ -70,6 +77,72 @@ func main() {
     }()
 
     time.Sleep(2 * time.Second)
+}
+```
+
+CANopen
+-------
+
+The `canopen` subpackage provides small, composable helpers for common CANopen tasks: NMT, heartbeat, EMCY, SDO expedited transfers, and a minimal synchronous SDO client that works over any `canbus.Bus` (e.g., `LoopbackBus` or SocketCAN).
+
+Example (CANopen SDO over loopback)
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "canbus"
+    "canbus/canopen"
+)
+
+func main() {
+    bus := canbus.NewLoopbackBus()
+    client := bus.Open()
+    server := bus.Open()
+    defer client.Close()
+    defer server.Close()
+
+    // Minimal CANopen SDO server: replies to download and upload for a single entry.
+    go func() {
+        for {
+            f, err := server.Receive()
+            if err != nil { return }
+            fc, node, err := canopen.ParseCOBID(f.ID)
+            if err != nil || fc != canopen.FC_SDO_RX || node != 0x22 { continue }
+            switch f.Data[0] >> 5 {
+            case 1: // initiate download request
+                var rsp canbus.Frame
+                rsp.ID = canopen.COBID(canopen.FC_SDO_TX, node)
+                rsp.Len = 8
+                rsp.Data[0] = byte(3 << 5) // download response
+                rsp.Data[1] = f.Data[1]
+                rsp.Data[2] = f.Data[2]
+                rsp.Data[3] = f.Data[3]
+                _ = server.Send(rsp)
+            case 2: // initiate upload request
+                var rsp canbus.Frame
+                rsp.ID = canopen.COBID(canopen.FC_SDO_TX, node)
+                rsp.Len = 8
+                rsp.Data[0] = byte(2<<5) | (1<<3) | (1<<2) | 0x01 // e=1, s=1, n=1 (3 bytes)
+                rsp.Data[1] = f.Data[1]
+                rsp.Data[2] = f.Data[2]
+                rsp.Data[3] = f.Data[3]
+                rsp.Data[4] = 0xDE; rsp.Data[5] = 0xAD; rsp.Data[6] = 0xBE
+                _ = server.Send(rsp)
+            }
+        }
+    }()
+
+    // Client side: perform expedited SDO download then upload
+    c := &canopen.SDOClient{Bus: client, Node: 0x22}
+    if err := c.Download(0x2000, 0x01, []byte{0xAA, 0xBB}); err != nil {
+        log.Fatal(err)
+    }
+    data, err := c.Upload(0x2000, 0x01)
+    if err != nil { log.Fatal(err) }
+    fmt.Printf("SDO read: % X\n", data) // prints: SDO read: DE AD BE
 }
 ```
 

--- a/canopen/canopen_test.go
+++ b/canopen/canopen_test.go
@@ -1,0 +1,120 @@
+package canopen
+
+import (
+    "bytes"
+    "encoding/binary"
+    "testing"
+
+    "canbus/canbus"
+)
+
+func TestCOBIDHelpers(t *testing.T) {
+    if id := COBID(FC_TPDO1, 1); id != 0x181 {
+        t.Fatalf("tpdo1 id: 0x%X", id)
+    }
+    if fc, node, err := ParseCOBID(0x5FF); err != nil || fc != FC_SDO_TX || node != 0x7F {
+        t.Fatalf("parse sdo tx: fc=%v node=%v err=%v", fc, node, err)
+    }
+}
+
+func TestNMTBuildParse(t *testing.T) {
+    f := BuildNMT(NMTStart, 0)
+    if cmd, node, err := ParseNMT(f); err != nil || cmd != NMTStart || node != 0 {
+        t.Fatalf("nmt parse mismatch: cmd=%v node=%d err=%v", cmd, node, err)
+    }
+}
+
+func TestHeartbeat(t *testing.T) {
+    f, err := BuildHeartbeat(10, StateOperational)
+    if err != nil { t.Fatal(err) }
+    node, st, err := ParseHeartbeat(f)
+    if err != nil { t.Fatal(err) }
+    if node != 10 || st != StateOperational {
+        t.Fatalf("heartbeat mismatch node=%d st=%v", node, st)
+    }
+}
+
+func TestEMCY(t *testing.T) {
+    e := Emergency{ErrorCode: 0x1234, ErrorRegister: 0x05}
+    f, err := BuildEMCY(5, e)
+    if err != nil { t.Fatal(err) }
+    node, g, err := ParseEMCY(f)
+    if err != nil { t.Fatal(err) }
+    if node != 5 || g.ErrorCode != 0x1234 || g.ErrorRegister != 0x05 {
+        t.Fatalf("emcy mismatch: node=%d g=%+v", node, g)
+    }
+}
+
+func TestSDOExpeditedHelpers(t *testing.T) {
+    data := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+    f, err := SDOExpeditedDownload(0x23, 0x2000, 0x01, data)
+    if err != nil { t.Fatal(err) }
+    node, idx, sub, got, err := ParseSDOExpeditedDownload(f)
+    if err != nil { t.Fatal(err) }
+    if node != 0x23 || idx != 0x2000 || sub != 0x01 || !bytes.Equal(got, data) {
+        t.Fatalf("sdo parse mismatch: node=%d idx=0x%X sub=%d data=%x", node, idx, sub, got)
+    }
+
+    req, err := SDOExpeditedUploadRequest(0x23, 0x1018, 0x00)
+    if err != nil { t.Fatal(err) }
+    if fc, node, err := ParseCOBID(req.ID); err != nil || fc != FC_SDO_RX || node != 0x23 {
+        t.Fatalf("upload req cobid: fc=%v node=%d err=%v", fc, node, err)
+    }
+}
+
+func TestSDOClientDownloadUpload(t *testing.T) {
+    bus := canbus.NewLoopbackBus()
+    clientEp := bus.Open()
+    serverEp := bus.Open()
+    defer clientEp.Close()
+    defer serverEp.Close()
+
+    // Minimal server: respond to download and upload requests for a single entry.
+    stored := []byte{0x01, 0x02, 0x03}
+    go func() {
+        for {
+            f, err := serverEp.Receive()
+            if err != nil { return }
+            fc, node, err := ParseCOBID(f.ID)
+            if err != nil { continue }
+            if fc != FC_SDO_RX || node != 0x22 {
+                continue
+            }
+            cmd := f.Data[0] >> 5
+            switch cmd {
+            case sdoCCSDownloadInitiate:
+                // respond with download response
+                var rsp canbus.Frame
+                rsp.ID = COBID(FC_SDO_TX, node)
+                rsp.Len = 8
+                rsp.Data[0] = byte(sdoSCSDownloadInitiate << 5)
+                rsp.Data[1] = f.Data[1]
+                rsp.Data[2] = f.Data[2]
+                rsp.Data[3] = f.Data[3]
+                _ = serverEp.Send(rsp)
+            case sdoCCSUploadInitiate:
+                var rsp canbus.Frame
+                rsp.ID = COBID(FC_SDO_TX, node)
+                rsp.Len = 8
+                // SCS=2, e=1, s=1, n=1 (3 bytes data)
+                rsp.Data[0] = byte(sdoSCSUploadInitiate<<5) | (1<<3) | (1<<2) | 0x01
+                binary.LittleEndian.PutUint16(rsp.Data[1:3], 0x2000)
+                rsp.Data[3] = 0x01
+                copy(rsp.Data[4:], stored)
+                _ = serverEp.Send(rsp)
+            }
+        }
+    }()
+
+    c := &SDOClient{Bus: clientEp, Node: 0x22}
+    if err := c.Download(0x2000, 0x01, []byte{0xAA, 0xBB}); err != nil {
+        t.Fatalf("download: %v", err)
+    }
+    // We ignore what server stores; upload returns fixed stored bytes
+    data, err := c.Upload(0x2000, 0x01)
+    if err != nil { t.Fatalf("upload: %v", err) }
+    if !bytes.Equal(data, stored) {
+        t.Fatalf("upload mismatch: %x", data)
+    }
+}
+

--- a/canopen/doc.go
+++ b/canopen/doc.go
@@ -1,0 +1,16 @@
+// Package canopen provides high-level helpers for building CANopen nodes
+// on top of the core canbus primitives.
+//
+// This package focuses on small, well-factored building blocks that cover
+// the most commonly used parts of CANopen:
+//   - COB-ID helpers and function code mapping
+//   - NMT commands and node state encoding/decoding
+//   - Heartbeat (NMT error control) producer/consumer byte
+//   - Emergency (EMCY) frame encode/decode
+//   - SDO expedited transfers (encode/decode) and a minimal synchronous client
+//
+// The APIs here do not attempt to implement the full CANopen stack or
+// object dictionary. Instead, they provide composable types and helpers that
+// are easy to test and integrate into applications.
+package canopen
+

--- a/canopen/emcy.go
+++ b/canopen/emcy.go
@@ -1,0 +1,54 @@
+package canopen
+
+import (
+    "encoding/binary"
+    "fmt"
+
+    "canbus/canbus"
+)
+
+// Emergency represents an EMCY message payload.
+//
+// Layout (8 bytes total):
+//   0..1: Error code (little-endian)
+//   2:    Error register
+//   3..7: Manufacturer specific data
+type Emergency struct {
+    ErrorCode      uint16
+    ErrorRegister  uint8
+    Manufacturer   [5]byte
+}
+
+// BuildEMCY builds an EMCY frame for the given node.
+func BuildEMCY(node NodeID, e Emergency) (canbus.Frame, error) {
+    if err := node.Validate(); err != nil {
+        return canbus.Frame{}, err
+    }
+    var f canbus.Frame
+    f.ID = COBID(FC_EMCY, node)
+    f.Len = 8
+    binary.LittleEndian.PutUint16(f.Data[0:2], e.ErrorCode)
+    f.Data[2] = e.ErrorRegister
+    copy(f.Data[3:8], e.Manufacturer[:])
+    return f, nil
+}
+
+// ParseEMCY decodes an EMCY payload from a CAN frame.
+func ParseEMCY(f canbus.Frame) (NodeID, Emergency, error) {
+    if f.Len < 8 {
+        return 0, Emergency{}, fmt.Errorf("canopen: emcy too short: %d", f.Len)
+    }
+    fc, node, err := ParseCOBID(f.ID)
+    if err != nil {
+        return 0, Emergency{}, err
+    }
+    if fc != FC_EMCY {
+        return 0, Emergency{}, fmt.Errorf("canopen: not an emcy frame (id=0x%X)", f.ID)
+    }
+    var e Emergency
+    e.ErrorCode = binary.LittleEndian.Uint16(f.Data[0:2])
+    e.ErrorRegister = f.Data[2]
+    copy(e.Manufacturer[:], f.Data[3:8])
+    return node, e, nil
+}
+

--- a/canopen/heartbeat.go
+++ b/canopen/heartbeat.go
@@ -1,0 +1,36 @@
+package canopen
+
+import (
+    "fmt"
+
+    "canbus/canbus"
+)
+
+// BuildHeartbeat produces an NMT error control heartbeat frame for node/state.
+// A heartbeat contains a single byte with the current NMTState.
+func BuildHeartbeat(node NodeID, state NMTState) (canbus.Frame, error) {
+    if err := node.Validate(); err != nil {
+        return canbus.Frame{}, err
+    }
+    var f canbus.Frame
+    f.ID = COBID(FC_NMT_ERRCTRL, node)
+    f.Len = 1
+    f.Data[0] = byte(state)
+    return f, nil
+}
+
+// ParseHeartbeat parses a heartbeat frame and returns node id and state.
+func ParseHeartbeat(f canbus.Frame) (NodeID, NMTState, error) {
+    if f.Len < 1 {
+        return 0, 0, fmt.Errorf("canopen: heartbeat too short: %d", f.Len)
+    }
+    fc, node, err := ParseCOBID(f.ID)
+    if err != nil {
+        return 0, 0, err
+    }
+    if fc != FC_NMT_ERRCTRL {
+        return 0, 0, fmt.Errorf("canopen: not a heartbeat frame (id=0x%X)", f.ID)
+    }
+    return node, NMTState(f.Data[0]), nil
+}
+

--- a/canopen/ids.go
+++ b/canopen/ids.go
@@ -1,0 +1,110 @@
+package canopen
+
+import "fmt"
+
+// NodeID represents a CANopen node identifier (1..127).
+// Value 0 is used for broadcast in some services (e.g., NMT) and is allowed
+// where explicitly documented.
+type NodeID uint8
+
+// Validate checks that the node identifier is in the range 1..127.
+func (n NodeID) Validate() error {
+    if n < 1 || n > 127 {
+        return fmt.Errorf("canopen: invalid node id %d (valid 1..127)", n)
+    }
+    return nil
+}
+
+// FunctionCode enumerates CANopen function code bases.
+// See CiA 301 table for COB-IDs.
+type FunctionCode uint16
+
+const (
+    // Fixed COB-IDs (no node id addition)
+    FC_SYNC        FunctionCode = 0x080
+    FC_TIME        FunctionCode = 0x100
+
+    // PDOs
+    FC_TPDO1       FunctionCode = 0x180
+    FC_RPDO1       FunctionCode = 0x200
+    FC_TPDO2       FunctionCode = 0x280
+    FC_RPDO2       FunctionCode = 0x300
+    FC_TPDO3       FunctionCode = 0x380
+    FC_RPDO3       FunctionCode = 0x400
+    FC_TPDO4       FunctionCode = 0x480
+    FC_RPDO4       FunctionCode = 0x500
+
+    // SDO
+    FC_SDO_TX      FunctionCode = 0x580 // server->client
+    FC_SDO_RX      FunctionCode = 0x600 // client->server
+
+    // NMT and error control
+    FC_NMT         FunctionCode = 0x000 // broadcast id for NMT
+    FC_NMT_ERRCTRL FunctionCode = 0x700 // heartbeat / node guarding
+
+    // Emergency
+    FC_EMCY        FunctionCode = 0x080 // + node id
+)
+
+// COBID composes the 11-bit CAN identifier for a function code and node id.
+// For function codes that are fixed (e.g., SYNC, TIME, NMT), the node id is
+// ignored.
+func COBID(fc FunctionCode, node NodeID) uint32 {
+    base := uint16(fc)
+    // Only NMT and TIME use fixed COB-IDs here. SYNC shares the 0x080 base
+    // with EMCY but EMCY requires adding node id, so SYNC is not treated as
+    // fixed in this helper to avoid ambiguity.
+    if fc == FC_NMT || fc == FC_TIME {
+        return uint32(base)
+    }
+    return uint32(base + uint16(node))
+}
+
+// ParseCOBID attempts to infer the function code and node id from the 11-bit id.
+// Note: For overlapping ranges (e.g. SYNC vs EMCY for node 0), or when multiple
+// function codes share bases, the mapping may not be unique. This helper returns
+// the most common mapping rules as used in practice.
+func ParseCOBID(id uint32) (FunctionCode, NodeID, error) {
+    if id > 0x7FF {
+        return 0, 0, fmt.Errorf("canopen: invalid 11-bit id 0x%X", id)
+    }
+    u := uint16(id)
+    switch {
+    case u == uint16(FC_NMT):
+        return FC_NMT, 0, nil
+    case u == uint16(FC_SYNC):
+        return FC_SYNC, 0, nil
+    case u == uint16(FC_TIME):
+        return FC_TIME, 0, nil
+    }
+    // Ranges with node id suffix
+    switch {
+    case u >= 0x080 && u <= 0x0FF:
+        return FC_EMCY, NodeID(u - 0x080), nil
+    case u >= 0x180 && u <= 0x1FF:
+        return FC_TPDO1, NodeID(u - 0x180), nil
+    case u >= 0x200 && u <= 0x27F:
+        return FC_RPDO1, NodeID(u - 0x200), nil
+    case u >= 0x280 && u <= 0x2FF:
+        return FC_TPDO2, NodeID(u - 0x280), nil
+    case u >= 0x300 && u <= 0x37F:
+        return FC_RPDO2, NodeID(u - 0x300), nil
+    case u >= 0x380 && u <= 0x3FF:
+        return FC_TPDO3, NodeID(u - 0x380), nil
+    case u >= 0x400 && u <= 0x47F:
+        return FC_RPDO3, NodeID(u - 0x400), nil
+    case u >= 0x480 && u <= 0x4FF:
+        return FC_TPDO4, NodeID(u - 0x480), nil
+    case u >= 0x500 && u <= 0x57F:
+        return FC_RPDO4, NodeID(u - 0x500), nil
+    case u >= 0x580 && u <= 0x5FF:
+        return FC_SDO_TX, NodeID(u - 0x580), nil
+    case u >= 0x600 && u <= 0x67F:
+        return FC_SDO_RX, NodeID(u - 0x600), nil
+    case u >= 0x700 && u <= 0x77F:
+        return FC_NMT_ERRCTRL, NodeID(u - 0x700), nil
+    default:
+        return 0, 0, fmt.Errorf("canopen: id 0x%X not in CANopen base ranges", id)
+    }
+}
+

--- a/canopen/nmt.go
+++ b/canopen/nmt.go
@@ -1,0 +1,50 @@
+package canopen
+
+import (
+    "fmt"
+
+    "canbus/canbus"
+)
+
+// NMTCommand is the command specifier for NMT service.
+type NMTCommand uint8
+
+const (
+    NMTStart           NMTCommand = 0x01
+    NMTStop            NMTCommand = 0x02
+    NMTEnterPreOperational NMTCommand = 0x80
+    NMTResetNode       NMTCommand = 0x81
+    NMTResetCommunication NMTCommand = 0x82
+)
+
+// NMTState encodes the node state as used in heartbeat.
+type NMTState uint8
+
+const (
+    StateBootup   NMTState = 0x00
+    StateStopped  NMTState = 0x04
+    StateOperational NMTState = 0x05
+    StatePreOperational NMTState = 0x7F
+)
+
+// BuildNMT builds an NMT command frame. node 0 means broadcast.
+func BuildNMT(cmd NMTCommand, node uint8) canbus.Frame {
+    var f canbus.Frame
+    f.ID = COBID(FC_NMT, 0)
+    f.Len = 2
+    f.Data[0] = byte(cmd)
+    f.Data[1] = byte(node)
+    return f
+}
+
+// ParseNMT decodes an NMT frame payload returning command and target node.
+func ParseNMT(f canbus.Frame) (NMTCommand, uint8, error) {
+    if f.ID != COBID(FC_NMT, 0) {
+        return 0, 0, fmt.Errorf("canopen: not an NMT frame (id=0x%X)", f.ID)
+    }
+    if f.Len < 2 {
+        return 0, 0, fmt.Errorf("canopen: NMT frame too short: %d", f.Len)
+    }
+    return NMTCommand(f.Data[0]), f.Data[1], nil
+}
+


### PR DESCRIPTION
Introduce a `canopen` subpackage to add idiomatic CANopen protocol support to the `canbus` library.

This PR implements core CANopen features including COB-ID helpers, NMT command building/parsing, Heartbeat production/consumption, EMCY frame encoding/decoding, and SDO expedited transfers with a synchronous client. All new components are designed for high quality and include comprehensive unit tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-70f31e7b-48da-42a8-8e6d-c6d4f3490803">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70f31e7b-48da-42a8-8e6d-c6d4f3490803">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

