### PR TITLE
Async SDO read non-blocking implementation

### DIFF
--- a/canbus/mux.go
+++ b/canbus/mux.go
@@ -1,0 +1,117 @@
+package canbus
+
+import (
+    "sync"
+)
+
+// FrameFilter decides whether a frame should be delivered to a subscriber.
+type FrameFilter func(Frame) bool
+
+// Mux multiplexes frames from a Bus to any number of subscribers via filters.
+//
+// It owns the provided Bus instance for receiving and runs a single background
+// goroutine to read from Receive and fan-out frames to subscribers. This avoids
+// having multiple goroutines competing to Receive and enables non-blocking,
+// filtered consumption for higher-level protocols like CANopen SDO.
+//
+// Send is not proxied; callers should keep using the original Bus to Send.
+type Mux struct {
+    bus   Bus
+    stop  chan struct{}
+
+    mu    sync.RWMutex
+    subs  map[uint64]*subscriber
+    next  uint64
+}
+
+type subscriber struct {
+    filter FrameFilter
+    ch     chan Frame
+}
+
+// NewMux creates and starts a multiplexer bound to the given Bus.
+func NewMux(bus Bus) *Mux {
+    m := &Mux{
+        bus:  bus,
+        stop: make(chan struct{}),
+        subs: make(map[uint64]*subscriber),
+    }
+    go m.run()
+    return m
+}
+
+// Close stops the background reader and closes all subscriber channels.
+func (m *Mux) Close() error {
+    select {
+    case <-m.stop:
+        return nil
+    default:
+    }
+    close(m.stop)
+    // Best-effort drain/close of subscribers
+    m.mu.Lock()
+    for id, s := range m.subs {
+        close(s.ch)
+        delete(m.subs, id)
+    }
+    m.mu.Unlock()
+    return nil
+}
+
+// Subscribe registers a new subscriber with the provided filter and channel buffer.
+// The returned channel will receive frames that match the filter. The cancel
+// function should be called when no longer needed; it will close the channel.
+func (m *Mux) Subscribe(filter FrameFilter, buffer int) (<-chan Frame, func()) {
+    if buffer < 0 {
+        buffer = 0
+    }
+    s := &subscriber{filter: filter, ch: make(chan Frame, buffer)}
+    m.mu.Lock()
+    id := m.next
+    m.next++
+    m.subs[id] = s
+    m.mu.Unlock()
+
+    cancel := func() {
+        m.mu.Lock()
+        if cur, ok := m.subs[id]; ok && cur == s {
+            close(cur.ch)
+            delete(m.subs, id)
+        }
+        m.mu.Unlock()
+    }
+    return s.ch, cancel
+}
+
+func (m *Mux) run() {
+    for {
+        select {
+        case <-m.stop:
+            return
+        default:
+        }
+        f, err := m.bus.Receive()
+        if err != nil {
+            // On error, propagate closure to subscribers and exit.
+            m.mu.Lock()
+            for id, s := range m.subs {
+                close(s.ch)
+                delete(m.subs, id)
+            }
+            m.mu.Unlock()
+            return
+        }
+        m.mu.RLock()
+        for _, s := range m.subs {
+            if s.filter == nil || s.filter(f) {
+                select {
+                case s.ch <- f:
+                default:
+                    // Drop if subscriber is slow and channel is full.
+                }
+            }
+        }
+        m.mu.RUnlock()
+    }
+}
+

--- a/canopen/sdo_async.go
+++ b/canopen/sdo_async.go
@@ -1,0 +1,128 @@
+package canopen
+
+import (
+    "encoding/binary"
+    "time"
+
+    "canbus/canbus"
+)
+
+// SDOAsyncClient provides non-blocking SDO operations by subscribing to a
+// frame multiplexer and matching responses by node/index/subindex.
+//
+// Use it with canbus.NewMux(bus) to avoid monopolizing bus.Receive.
+type SDOAsyncClient struct {
+    Bus  canbus.Bus   // for Send
+    Mux  *canbus.Mux  // for Receive fan-out
+    Node NodeID
+}
+
+// DownloadAsync sends an expedited download and returns a channel that will be
+// closed with a nil error when the server acknowledges, or with an error if
+// the mux/bus closes. It does not block reads from other consumers.
+func (c *SDOAsyncClient) DownloadAsync(index uint16, subindex uint8) (<-chan error, error) {
+    req, err := SDOExpeditedDownload(c.Node, index, subindex, nil)
+    if err != nil {
+        return nil, err
+    }
+    // Subscribe to matching SDO_TX response for this node and index/subindex.
+    ch, cancel := c.Mux.Subscribe(func(f canbus.Frame) bool {
+        fc, node, err := ParseCOBID(f.ID)
+        if err != nil || fc != FC_SDO_TX || node != c.Node || f.Len != 8 {
+            return false
+        }
+        cmd := f.Data[0]
+        if (cmd>>5)&0x7 != sdoSCSDownloadInitiate {
+            return false
+        }
+        idx := binary.LittleEndian.Uint16(f.Data[1:3])
+        sub := f.Data[3]
+        return idx == index && sub == subindex
+    }, 1)
+
+    out := make(chan error, 1)
+    // Send request before waiting.
+    if err := c.Bus.Send(req); err != nil {
+        cancel()
+        return nil, err
+    }
+    go func() {
+        defer cancel()
+        // Wait for first matching frame or closure.
+        if _, ok := <-ch; !ok {
+            out <- canbus.ErrClosed
+            close(out)
+            return
+        }
+        out <- nil
+        close(out)
+    }()
+    return out, nil
+}
+
+// UploadAsync sends an expedited upload request and returns a channel that will
+// yield the response bytes or an error. The optional timeout cancels waiting.
+func (c *SDOAsyncClient) UploadAsync(index uint16, subindex uint8, timeout time.Duration) (<-chan []byte, <-chan error, error) {
+    req, err := SDOExpeditedUploadRequest(c.Node, index, subindex)
+    if err != nil {
+        return nil, nil, err
+    }
+    ch, cancel := c.Mux.Subscribe(func(f canbus.Frame) bool {
+        fc, node, err := ParseCOBID(f.ID)
+        if err != nil || fc != FC_SDO_TX || node != c.Node || f.Len != 8 {
+            return false
+        }
+        return true
+    }, 2)
+
+    dataCh := make(chan []byte, 1)
+    errCh := make(chan error, 1)
+
+    if err := c.Bus.Send(req); err != nil {
+        cancel()
+        return nil, nil, err
+    }
+
+    // Optional timeout
+    var timeoutC <-chan time.Time
+    if timeout > 0 {
+        timer := time.NewTimer(timeout)
+        timeoutC = timer.C
+        // Ensure timer is stopped when done
+        defer func() {
+            if !timer.Stop() {
+                select { case <-timer.C: default: }
+            }
+        }()
+    }
+
+    go func() {
+        defer cancel()
+        for {
+            select {
+            case f, ok := <-ch:
+                if !ok {
+                    errCh <- canbus.ErrClosed
+                    close(errCh)
+                    close(dataCh)
+                    return
+                }
+                _, idx, sub, data, perr := ParseSDOExpeditedUploadResponse(f)
+                if perr != nil || idx != index || sub != subindex {
+                    continue
+                }
+                dataCh <- data
+                close(dataCh)
+                close(errCh)
+                return
+            case <-timeoutC:
+                errCh <- canbus.ErrClosed
+                close(errCh)
+                close(dataCh)
+                return
+            }
+        }
+    }()
+    return dataCh, errCh, nil
+}
+


### PR DESCRIPTION
Add an async SDO client and a CAN frame multiplexer to enable non-blocking SDO operations and prevent monopolizing bus reads.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f90a1a2-a2cb-4713-b1b2-bf58b05301d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f90a1a2-a2cb-4713-b1b2-bf58b05301d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

