### PR TITLE
Optimize sdo handling with multiplexer

### DIFF
--- a/canopen/sdo_async.go
+++ b/canopen/sdo_async.go
@@ -107,7 +107,7 @@ func (c *SDOAsyncClient) UploadAsync(index uint16, subindex uint8, timeout time.
                     close(dataCh)
                     return
                 }
-                _, idx, sub, data, perr := ParseSDOExpeditedUploadResponse(f)
+                _, idx, sub, data, perr := parseSDOExpeditedUploadResponse(f)
                 if perr != nil || idx != index || sub != subindex {
                     continue
                 }


### PR DESCRIPTION
Refactor `SDOClient` to offer a single, synchronous-looking API that uses `canbus.Mux` for non-blocking operations and includes typed marshal/unmarshal helpers.

---
<a href="https://cursor.com/background-agent?bcId=bc-2cb3b9b5-1a84-4a75-b08d-6c90b8eeacf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2cb3b9b5-1a84-4a75-b08d-6c90b8eeacf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

