### PR TITLE
Expand sdo support and privatize internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Features
   - NMT build/parse utilities
   - Heartbeat (NMT error control) build/parse
   - EMCY encode/decode
-  - SDO expedited helpers and a minimal synchronous SDO client
+  - SDO client supporting expedited (≤4 bytes) and segmented transfers
   
 
 Install
@@ -101,7 +101,7 @@ func main() {
 CANopen
 -------
 
-The `canopen` subpackage provides small, composable helpers for common CANopen tasks: NMT, heartbeat, EMCY, SDO expedited transfers, and a minimal synchronous SDO client that works over any `canbus.Bus` (e.g., `LoopbackBus` or SocketCAN).
+The `canopen` subpackage provides small, composable helpers for common CANopen tasks: NMT, heartbeat, EMCY, and SDO (expedited and segmented) with a synchronous SDO client that works over any `canbus.Bus` (e.g., `LoopbackBus` or SocketCAN).
 
 Example (CANopen SDO over loopback)
 ```go
@@ -127,7 +127,7 @@ func main() {
     mux := canbus.NewMux(clientRx)
     defer mux.Close()
     c := canopen.NewSDOClient(clientTx, 0x22, mux, 0)
-    // Requires an SDO server at node 0x22 present on the bus.
+    // Download auto-selects expedited (≤4 bytes) or segmented (>4 bytes)
     if err := c.Download(0x2000, 0x01, []byte{0xAA, 0xBB}); err != nil {
         log.Fatal(err)
     }

--- a/canopen/sdo.go
+++ b/canopen/sdo.go
@@ -8,19 +8,30 @@ import (
     "github.com/notnil/canbus"
 )
 
-// SDO command specifiers for initiate download/upload expedited
+// SDO command specifiers (CCS/SCS) per CiA 301
 const (
+    // Initiate (expedited or segmented negotiated during initiate)
     sdoCCSDownloadInitiate = 1 // client->server
     sdoCCSUploadInitiate   = 2 // client->server
     sdoSCSDownloadInitiate = 3 // server->client
     sdoSCSUploadInitiate   = 2 // server->client
+
+    // Segmented phase
+    sdoCCSDownloadSegment  = 0 // client->server
+    sdoSCSDownloadSegment  = 1 // server->client
+    sdoCCSUploadSegment    = 3 // client->server
+    sdoSCSUploadSegment    = 0 // server->client
+
+    // Abort
+    sdoCCSAbort            = 4
+    sdoSCSAbort            = 4
 )
 
 // (no generic command builder is exposed; helpers below encode per CiA 301)
 
-// SDOExpeditedDownload builds client->server expedited download frame (write).
+// sdoExpeditedDownload builds client->server expedited download frame (write).
 // It encodes index/subindex and up to 4 data bytes.
-func SDOExpeditedDownload(target NodeID, index uint16, subindex uint8, data []byte) (canbus.Frame, error) {
+func sdoExpeditedDownload(target NodeID, index uint16, subindex uint8, data []byte) (canbus.Frame, error) {
     if err := target.Validate(); err != nil {
         return canbus.Frame{}, err
     }
@@ -83,8 +94,8 @@ func parseSDOExpeditedDownload(f canbus.Frame) (NodeID, uint16, uint8, []byte, e
     return node, idx, sub, out, nil
 }
 
-// SDOExpeditedUploadRequest builds client->server request to read an object.
-func SDOExpeditedUploadRequest(target NodeID, index uint16, subindex uint8) (canbus.Frame, error) {
+// sdoExpeditedUploadRequest builds client->server request to read an object.
+func sdoExpeditedUploadRequest(target NodeID, index uint16, subindex uint8) (canbus.Frame, error) {
     if err := target.Validate(); err != nil {
         return canbus.Frame{}, err
     }
@@ -153,14 +164,15 @@ func NewSDOClient(bus canbus.Bus, node NodeID, mux *canbus.Mux, timeout time.Dur
     return &SDOClient{bus: bus, node: node, mux: mux, timeout: timeout}
 }
 
-// Download writes up to 4 bytes to index/subindex using expedited transfer.
+// Download writes data to index/subindex. It uses expedited transfer for sizes
+// up to 4 bytes and segmented transfer for larger payloads.
 func (c *SDOClient) Download(index uint16, subindex uint8, data []byte) error {
-    req, err := SDOExpeditedDownload(c.node, index, subindex, data)
-    if err != nil {
-        return err
-    }
+    if len(data) <= 4 {
+        req, err := sdoExpeditedDownload(c.node, index, subindex, data)
+        if err != nil {
+            return err
+        }
 
-    // Wait for response via mux
         ch, cancel := c.mux.Subscribe(func(f canbus.Frame) bool {
             fc, node, err := ParseCOBID(f.ID)
             if err != nil || fc != FC_SDO_TX || node != c.node || f.Len != 8 {
@@ -192,11 +204,100 @@ func (c *SDOClient) Download(index uint16, subindex uint8, data []byte) error {
             return canbus.ErrClosed
         }
         return nil
+    }
+
+    // Segmented download
+    // Initiate segmented download with size indicated
+    var init canbus.Frame
+    init.ID = COBID(FC_SDO_RX, c.node)
+    init.Len = 8
+    cmd := byte(sdoCCSDownloadInitiate << 5) | (1 << 2) // s=1, e=0
+    init.Data[0] = cmd
+    binary.LittleEndian.PutUint16(init.Data[1:3], index)
+    init.Data[3] = subindex
+    total := uint32(len(data))
+    binary.LittleEndian.PutUint32(init.Data[4:8], total)
+
+    // Wait for initiate response
+    chInit, cancelInit := c.mux.Subscribe(func(f canbus.Frame) bool {
+        fc, node, err := ParseCOBID(f.ID)
+        if err != nil || fc != FC_SDO_TX || node != c.node || f.Len != 8 {
+            return false
+        }
+        if (f.Data[0]>>5)&0x7 != sdoSCSDownloadInitiate { return false }
+        idx := binary.LittleEndian.Uint16(f.Data[1:3])
+        sub := f.Data[3]
+        return idx == index && sub == subindex
+    }, 1)
+    defer cancelInit()
+    if err := c.bus.Send(init); err != nil { return err }
+    if c.timeout > 0 {
+        select {
+        case _, ok := <-chInit:
+            if !ok { return canbus.ErrClosed }
+        case <-time.After(c.timeout):
+            return canbus.ErrClosed
+        }
+    } else {
+        if _, ok := <-chInit; !ok { return canbus.ErrClosed }
+    }
+
+    // Send segments with toggle bit alternated, wait for ack after each
+    toggle := byte(0)
+    sent := 0
+    for sent < len(data) {
+        remain := len(data) - sent
+        segLen := 7
+        if remain < segLen { segLen = remain }
+        last := sent+segLen == len(data)
+        var seg canbus.Frame
+        seg.ID = COBID(FC_SDO_RX, c.node)
+        seg.Len = 8
+        segCmd := byte(sdoCCSDownloadSegment << 5)
+        if toggle&1 == 1 { segCmd |= 1 << 4 }
+        if last {
+            n := byte(7 - segLen) // number of unused bytes in last segment
+            segCmd |= 1 // c=1 last
+            segCmd |= (n & 0x7) << 1
+        }
+        seg.Data[0] = segCmd
+        copy(seg.Data[1:1+segLen], data[sent:sent+segLen])
+
+        // Prepare waiter for ack
+        chSeg, cancelSeg := c.mux.Subscribe(func(f canbus.Frame) bool {
+            fc, node, err := ParseCOBID(f.ID)
+            if err != nil || fc != FC_SDO_TX || node != c.node || f.Len != 8 {
+                return false
+            }
+            if (f.Data[0]>>5)&0x7 != sdoSCSDownloadSegment { return false }
+            // Toggle bit must match
+            t := (f.Data[0] >> 4) & 0x1
+            return t == (toggle & 0x1)
+        }, 1)
+
+        // Send and wait
+        if err := c.bus.Send(seg); err != nil { cancelSeg(); return err }
+        if c.timeout > 0 {
+            select {
+            case _, ok := <-chSeg:
+                cancelSeg(); if !ok { return canbus.ErrClosed }
+            case <-time.After(c.timeout):
+                cancelSeg(); return canbus.ErrClosed
+            }
+        } else {
+            if _, ok := <-chSeg; !ok { cancelSeg(); return canbus.ErrClosed }
+            cancelSeg()
+        }
+
+        sent += segLen
+        toggle ^= 1
+    }
+    return nil
 }
 
-// Upload reads up to 4 bytes via expedited transfer.
+// Upload reads an object. It supports both expedited and segmented transfers.
 func (c *SDOClient) Upload(index uint16, subindex uint8) ([]byte, error) {
-    req, err := SDOExpeditedUploadRequest(c.node, index, subindex)
+    req, err := sdoExpeditedUploadRequest(c.node, index, subindex)
     if err != nil {
         return nil, err
     }
@@ -215,26 +316,102 @@ func (c *SDOClient) Upload(index uint16, subindex uint8) ([]byte, error) {
         return nil, err
     }
 
+    // First response decides expedited vs segmented
+    var first canbus.Frame
     if c.timeout > 0 {
-        timeout := time.After(c.timeout)
-        for {
-            select {
-            case f, ok := <-ch:
-                if !ok { return nil, canbus.ErrClosed }
-                _, idx, sub, data, perr := parseSDOExpeditedUploadResponse(f)
-                if perr != nil || idx != index || sub != subindex { continue }
-                return data, nil
-            case <-timeout:
-                return nil, canbus.ErrClosed
-            }
+        select {
+        case f, ok := <-ch:
+            if !ok { return nil, canbus.ErrClosed }
+            first = f
+        case <-time.After(c.timeout):
+            return nil, canbus.ErrClosed
         }
-    }
-    for {
+    } else {
         f, ok := <-ch
         if !ok { return nil, canbus.ErrClosed }
-        _, idx, sub, data, perr := parseSDOExpeditedUploadResponse(f)
-        if perr != nil || idx != index || sub != subindex { continue }
+        first = f
+    }
+
+    // Try expedited parse
+    if _, idx, sub, data, perr := parseSDOExpeditedUploadResponse(first); perr == nil && idx == index && sub == subindex {
         return data, nil
+    }
+
+    // Segmented upload initiate response expected
+    if (first.Data[0]>>5)&0x7 != sdoSCSUploadInitiate {
+        return nil, fmt.Errorf("canopen: unexpected SDO response 0x%02X", first.Data[0])
+    }
+    // e=0 for segmented
+    if (first.Data[0]&(1<<3)) != 0 {
+        return nil, fmt.Errorf("canopen: unexpected expedited flag in segmented upload response")
+    }
+    // size indicated?
+    var total int = -1
+    if (first.Data[0]&(1<<2)) != 0 {
+        total = int(binary.LittleEndian.Uint32(first.Data[4:8]))
+    }
+    // Index/subindex must match
+    if binary.LittleEndian.Uint16(first.Data[1:3]) != index || first.Data[3] != subindex {
+        return nil, fmt.Errorf("canopen: upload initiate index mismatch")
+    }
+
+    // Now perform segmented upload loop
+    out := make([]byte, 0, 256)
+    toggle := byte(0)
+    for {
+        // Send upload segment request
+        var reqSeg canbus.Frame
+        reqSeg.ID = COBID(FC_SDO_RX, c.node)
+        reqSeg.Len = 8
+        cmd := byte(sdoCCSUploadSegment << 5)
+        if toggle&1 == 1 { cmd |= 1 << 4 }
+        reqSeg.Data[0] = cmd
+        // rest bytes zero
+
+        // Subscribe for matching segment response with toggle
+        chSeg, cancelSeg := c.mux.Subscribe(func(f canbus.Frame) bool {
+            fc, node, err := ParseCOBID(f.ID)
+            if err != nil || fc != FC_SDO_TX || node != c.node || f.Len != 8 { return false }
+            if (f.Data[0]>>5)&0x7 != sdoSCSUploadSegment { return false }
+            t := (f.Data[0] >> 4) & 0x1
+            return t == (toggle & 0x1)
+        }, 1)
+
+        if err := c.bus.Send(reqSeg); err != nil { cancelSeg(); return nil, err }
+        var rsp canbus.Frame
+        if c.timeout > 0 {
+            select {
+            case f, ok := <-chSeg:
+                cancelSeg(); if !ok { return nil, canbus.ErrClosed }
+                rsp = f
+            case <-time.After(c.timeout):
+                cancelSeg(); return nil, canbus.ErrClosed
+            }
+        } else {
+            f, ok := <-chSeg
+            cancelSeg()
+            if !ok { return nil, canbus.ErrClosed }
+            rsp = f
+        }
+
+        // Extract data and flags
+        cFlag := (rsp.Data[0] & 0x1) != 0
+        n := int((rsp.Data[0] >> 1) & 0x7) // number of unused bytes in this segment if last
+        segDataEnd := 8
+        if cFlag {
+            segDataEnd = 8 - n
+        }
+        if segDataEnd < 1 || segDataEnd > 8 { return nil, fmt.Errorf("canopen: invalid segment length") }
+        out = append(out, rsp.Data[1:segDataEnd]...)
+
+        toggle ^= 1
+        if cFlag {
+            if total >= 0 && len(out) != total {
+                // Some devices may not set size; tolerate mismatch only if size unknown
+                if total >= 0 { return nil, fmt.Errorf("canopen: segmented upload size mismatch: got %d want %d", len(out), total) }
+            }
+            return out, nil
+        }
     }
 }
 


### PR DESCRIPTION
Expand SDO client to support both expedited and segmented transfers, and make internal SDO helper functions private.

---
<a href="https://cursor.com/background-agent?bcId=bc-00dffda0-c579-42f2-bbd9-42a377eede3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-00dffda0-c579-42f2-bbd9-42a377eede3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

