### PR TITLE
Implement logged bus with configurable log level

### DIFF
--- a/logged.go
+++ b/logged.go
@@ -1,0 +1,92 @@
+package canbus
+
+// LoggedBus is a Bus decorator that logs Send/Receive operations using a
+// provided structured logger.
+
+// LogLevel represents a logging severity.
+type LogLevel int
+
+const (
+    LevelDebug LogLevel = iota
+    LevelInfo
+    LevelWarn
+    LevelError
+)
+
+// StructuredLogger is a minimal structured logger interface expected by
+// LoggedBus. Key/value arguments should be provided as alternating key (string)
+// and value pairs, e.g.: "key1", val1, "key2", val2.
+type StructuredLogger interface {
+    Log(level LogLevel, msg string, kv ...any)
+}
+
+// NewLoggedBus wraps the given Bus and logs reads, writes, or both at the given
+// level. When logReads/logWrites are false, the corresponding operation is not
+// logged.
+func NewLoggedBus(inner Bus, logger StructuredLogger, level LogLevel, logReads, logWrites bool) Bus {
+    return &loggedBus{
+        inner:     inner,
+        logger:    logger,
+        level:     level,
+        logReads:  logReads,
+        logWrites: logWrites,
+    }
+}
+
+type loggedBus struct {
+    inner     Bus
+    logger    StructuredLogger
+    level     LogLevel
+    logReads  bool
+    logWrites bool
+}
+
+// Send logs the frame and the result when write logging is enabled.
+func (l *loggedBus) Send(frame Frame) error {
+    if l.logWrites {
+        l.logger.Log(l.level, "canbus send",
+            "id", frame.ID,
+            "extended", frame.Extended,
+            "rtr", frame.RTR,
+            "len", int(frame.Len),
+            "data", frame.Data[:frame.Len],
+            "string", frame.String(),
+        )
+    }
+    err := l.inner.Send(frame)
+    if l.logWrites && err != nil {
+        l.logger.Log(LevelError, "canbus send error",
+            "id", frame.ID,
+            "error", err,
+        )
+    }
+    return err
+}
+
+// Receive logs the received frame or error when read logging is enabled.
+func (l *loggedBus) Receive() (Frame, error) {
+    f, err := l.inner.Receive()
+    if l.logReads {
+        if err != nil {
+            l.logger.Log(LevelError, "canbus receive error",
+                "error", err,
+            )
+        } else {
+            l.logger.Log(l.level, "canbus receive",
+                "id", f.ID,
+                "extended", f.Extended,
+                "rtr", f.RTR,
+                "len", int(f.Len),
+                "data", f.Data[:f.Len],
+                "string", f.String(),
+            )
+        }
+    }
+    return f, err
+}
+
+// Close forwards to the inner Bus without logging.
+func (l *loggedBus) Close() error {
+    return l.inner.Close()
+}
+

--- a/logged.go
+++ b/logged.go
@@ -1,29 +1,17 @@
 package canbus
 
-// LoggedBus is a Bus decorator that logs Send/Receive operations using a
-// provided structured logger.
-
-// LogLevel represents a logging severity.
-type LogLevel int
-
-const (
-    LevelDebug LogLevel = iota
-    LevelInfo
-    LevelWarn
-    LevelError
+import (
+    "context"
+    "log/slog"
 )
 
-// StructuredLogger is a minimal structured logger interface expected by
-// LoggedBus. Key/value arguments should be provided as alternating key (string)
-// and value pairs, e.g.: "key1", val1, "key2", val2.
-type StructuredLogger interface {
-    Log(level LogLevel, msg string, kv ...any)
-}
+// LoggedBus is a Bus decorator that logs Send/Receive operations using a
+// slog.Logger.
 
 // NewLoggedBus wraps the given Bus and logs reads, writes, or both at the given
 // level. When logReads/logWrites are false, the corresponding operation is not
 // logged.
-func NewLoggedBus(inner Bus, logger StructuredLogger, level LogLevel, logReads, logWrites bool) Bus {
+func NewLoggedBus(inner Bus, logger *slog.Logger, level slog.Level, logReads, logWrites bool) Bus {
     return &loggedBus{
         inner:     inner,
         logger:    logger,
@@ -35,8 +23,8 @@ func NewLoggedBus(inner Bus, logger StructuredLogger, level LogLevel, logReads, 
 
 type loggedBus struct {
     inner     Bus
-    logger    StructuredLogger
-    level     LogLevel
+    logger    *slog.Logger
+    level     slog.Level
     logReads  bool
     logWrites bool
 }
@@ -44,7 +32,7 @@ type loggedBus struct {
 // Send logs the frame and the result when write logging is enabled.
 func (l *loggedBus) Send(frame Frame) error {
     if l.logWrites {
-        l.logger.Log(l.level, "canbus send",
+        l.logger.Log(context.Background(), l.level, "canbus send",
             "id", frame.ID,
             "extended", frame.Extended,
             "rtr", frame.RTR,
@@ -55,7 +43,7 @@ func (l *loggedBus) Send(frame Frame) error {
     }
     err := l.inner.Send(frame)
     if l.logWrites && err != nil {
-        l.logger.Log(LevelError, "canbus send error",
+        l.logger.Log(context.Background(), slog.LevelError, "canbus send error",
             "id", frame.ID,
             "error", err,
         )
@@ -68,11 +56,11 @@ func (l *loggedBus) Receive() (Frame, error) {
     f, err := l.inner.Receive()
     if l.logReads {
         if err != nil {
-            l.logger.Log(LevelError, "canbus receive error",
+            l.logger.Log(context.Background(), slog.LevelError, "canbus receive error",
                 "error", err,
             )
         } else {
-            l.logger.Log(l.level, "canbus receive",
+            l.logger.Log(context.Background(), l.level, "canbus receive",
                 "id", f.ID,
                 "extended", f.Extended,
                 "rtr", f.RTR,

--- a/logged_test.go
+++ b/logged_test.go
@@ -1,0 +1,81 @@
+package canbus
+
+import (
+    "testing"
+)
+
+type kvPair struct{
+    key string
+    val any
+}
+
+type testLogEntry struct{
+    level LogLevel
+    msg   string
+    kvs   []kvPair
+}
+
+type testLogger struct{
+    entries []testLogEntry
+}
+
+func (t *testLogger) Log(level LogLevel, msg string, kv ...any) {
+    e := testLogEntry{level: level, msg: msg}
+    for i := 0; i+1 < len(kv); i+=2 {
+        k, _ := kv[i].(string)
+        e.kvs = append(e.kvs, kvPair{key: k, val: kv[i+1]})
+    }
+    t.entries = append(t.entries, e)
+}
+
+func hasMsg(entries []testLogEntry, level LogLevel, msg string) bool {
+    for _, e := range entries {
+        if e.level == level && e.msg == msg {
+            return true
+        }
+    }
+    return false
+}
+
+func TestLoggedBus_WriteAndReadLogging(t *testing.T) {
+    lb := NewLoopbackBus()
+    defer lb.Close()
+
+    logger := &testLogger{}
+    // Wrap both endpoints to verify read and write logging independently.
+    sender := NewLoggedBus(lb.Open(), logger, LevelInfo, false, true)
+    receiver := NewLoggedBus(lb.Open(), logger, LevelInfo, true, false)
+    defer sender.Close()
+    defer receiver.Close()
+
+    frame := MustFrame(0x123, []byte{1,2,3})
+    if err := sender.Send(frame); err != nil {
+        t.Fatalf("send: %v", err)
+    }
+    if _, err := receiver.Receive(); err != nil {
+        t.Fatalf("receive: %v", err)
+    }
+
+    if !hasMsg(logger.entries, LevelInfo, "canbus send") {
+        t.Fatalf("expected write log entry")
+    }
+    if !hasMsg(logger.entries, LevelInfo, "canbus receive") {
+        t.Fatalf("expected read log entry")
+    }
+}
+
+func TestLoggedBus_ErrorLogging(t *testing.T) {
+    lb := NewLoopbackBus()
+    // Create and immediately close a receiver to force error on Receive
+    rx := lb.Open()
+    _ = rx.Close()
+
+    logger := &testLogger{}
+    wrapped := NewLoggedBus(rx, logger, LevelInfo, true, false)
+    _, _ = wrapped.Receive()
+
+    if !hasMsg(logger.entries, LevelError, "canbus receive error") {
+        t.Fatalf("expected receive error log entry")
+    }
+}
+

--- a/logged_test.go
+++ b/logged_test.go
@@ -40,8 +40,8 @@ func TestLoggedBus_WriteAndReadLogging(t *testing.T) {
     logger := slog.New(sink)
 
     // Wrap both endpoints to verify read and write logging independently.
-    sender := NewLoggedBus(lb.Open(), logger, slog.LevelInfo, false, true)
-    receiver := NewLoggedBus(lb.Open(), logger, slog.LevelInfo, true, false)
+    sender := NewLoggedBus(lb.Open(), logger, slog.LevelInfo, LogWrite)
+    receiver := NewLoggedBus(lb.Open(), logger, slog.LevelInfo, LogRead)
     defer sender.Close()
     defer receiver.Close()
 
@@ -69,7 +69,7 @@ func TestLoggedBus_ErrorLogging(t *testing.T) {
 
     sink := &recordSink{}
     logger := slog.New(sink)
-    wrapped := NewLoggedBus(rx, logger, slog.LevelInfo, true, false)
+    wrapped := NewLoggedBus(rx, logger, slog.LevelInfo, LogRead)
     _, _ = wrapped.Receive()
 
     if !hasSlogMsg(sink.records, slog.LevelError, "canbus receive error") {


### PR DESCRIPTION
Add `LoggedBus` decorator to log CAN bus read and write operations with a configurable log level and structured logger.

---
<a href="https://cursor.com/background-agent?bcId=bc-34e7fa83-a529-4416-918f-72765640bede">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34e7fa83-a529-4416-918f-72765640bede">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

