### PR TITLE
Enable classic expedited sdo write support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ bus := canbus.NewLoopbackBus() // or a real bus (e.g., SocketCAN)
 tx := bus.Open()               // client transmit endpoint
 rx := bus.Open()               // client receive endpoint (owned by mux)
 mux := canbus.NewMux(rx)
-client := canopen.NewSDOClient(tx, 0x22, mux, 0) // zero timeout waits indefinitely
+client := canopen.NewSDOClient(tx, 0x22, mux) // default: wait indefinitely, spec mode
 
 // Write then read using expedited transfer (≤ 4 bytes)
 _ = client.WriteU16(0x2000, 0x01, 0xBEEF)
@@ -186,7 +186,8 @@ _ = b; _ = err
 
 Notes
 - The SDO client requires a non-nil `Mux` and uses it to wait for responses without racing other receivers.
-- Timeouts: pass a non-zero duration to `NewSDOClient` for bounded waits.
+- Timeouts: pass `WithTimeout(d)` to `NewSDOClient` for bounded waits.
+- Classic expedited writes: use `WithExpeditedMode(canopen.ExpeditedModeClassic)` if your device expects 0x23/0x27/0x2B/0x2F command bytes.
 - Heartbeat and EMCY include marshal/unmarshal helpers and idiomatic types.
 
 API reference

--- a/canopen/canopen_test.go
+++ b/canopen/canopen_test.go
@@ -114,8 +114,7 @@ func TestSDOClientClassicExpeditedEndToEnd(t *testing.T) {
 
     mux := canbus.NewMux(client)
     defer mux.Close()
-    c := NewSDOClient(client, 0x5A, mux, time.Second)
-    c.SetClassicExpedited(true)
+    c := NewSDOClientWithMode(client, 0x5A, mux, time.Second, ExpeditedModeClassic)
 
     // 4 bytes should produce 0x23; 1 byte should produce 0x2F. We cannot read
     // what was sent through mux directly here; instead, ensure the transfer

--- a/canopen/canopen_test.go
+++ b/canopen/canopen_test.go
@@ -114,7 +114,7 @@ func TestSDOClientClassicExpeditedEndToEnd(t *testing.T) {
 
     mux := canbus.NewMux(client)
     defer mux.Close()
-    c := NewSDOClientWithMode(client, 0x5A, mux, time.Second, ExpeditedModeClassic)
+    c := NewSDOClient(client, 0x5A, mux, WithTimeout(time.Second), WithExpeditedMode(ExpeditedModeClassic))
 
     // 4 bytes should produce 0x23; 1 byte should produce 0x2F. We cannot read
     // what was sent through mux directly here; instead, ensure the transfer
@@ -169,7 +169,7 @@ func TestSDOClientDownloadUpload(t *testing.T) {
 
     mux := canbus.NewMux(clientEp)
     defer mux.Close()
-    c := NewSDOClient(clientEp, 0x22, mux, 0)
+    c := NewSDOClient(clientEp, 0x22, mux)
     if err := c.Download(0x2000, 0x01, []byte{0xAA, 0xBB}); err != nil {
         t.Fatalf("download: %v", err)
     }
@@ -281,7 +281,7 @@ func TestSDOSegmentedDownloadUpload(t *testing.T) {
 
     mux := canbus.NewMux(clientEp)
     defer mux.Close()
-    c := NewSDOClient(clientEp, 0x33, mux, time.Second)
+    c := NewSDOClient(clientEp, 0x33, mux, WithTimeout(time.Second))
 
     if err := c.Download(0x3000, 0x02, writeData); err != nil {
         t.Fatalf("segmented download: %v", err)
@@ -333,7 +333,7 @@ func TestSDOAsyncOverLoopback(t *testing.T) {
         }
     }()
 
-    client := NewSDOClient(tx, 0x11, mux, time.Second)
+    client := NewSDOClient(tx, 0x11, mux, WithTimeout(time.Second))
 
     // Issue download and ensure it completes
     if err := client.Download(0x2000, 0x01, []byte{0x01}); err != nil { t.Fatal(err) }
@@ -441,7 +441,7 @@ func TestSDOAbortDownloadAndUpload(t *testing.T) {
 
     mux := canbus.NewMux(client)
     defer mux.Close()
-    c := NewSDOClient(client, 0x55, mux, time.Second)
+    c := NewSDOClient(client, 0x55, mux, WithTimeout(time.Second))
 
     // Download should return SDOAbort
     if err := c.Download(0x2000, 0x01, []byte{0xAA}); err == nil {

--- a/canopen/sdo.go
+++ b/canopen/sdo.go
@@ -63,11 +63,7 @@ func NewSDOClient(bus canbus.Bus, node NodeID, mux *canbus.Mux, opts ...SDOClien
     return c
 }
 
-// SetClassicExpedited enables or disables the classic expedited download
-// encoding for the command byte (0x23/0x27/0x2B/0x2F). When disabled, the
-// command byte is encoded strictly per CiA 301 bitfields (yielding
-// 0x2C/0x2D/0x2E/0x2F for 4/3/2/1 bytes respectively).
-// (runtime setter removed; select mode via constructor)
+//
 
 // Download writes data to index/subindex. It uses expedited transfer for sizes
 // up to 4 bytes and segmented transfer for larger payloads.


### PR DESCRIPTION
Add a compatibility mode for 'classic' expedited SDO writes to support devices that require legacy command byte encodings.

Some devices, such as ZLTech drives, do not accept the CiA 301 bitfield-derived command bytes (e.g., `0x2C` for 4 bytes) for expedited SDO downloads, instead requiring older, widely-used constants (e.g., `0x23` for 4 bytes). This change allows the `SDOClient` to be configured to emit these 'classic' values.

---
<a href="https://cursor.com/background-agent?bcId=bc-1701b63e-1fb4-4fed-996b-6019cf38a73b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1701b63e-1fb4-4fed-996b-6019cf38a73b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

