### PR TITLE
Configure linux socket can options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ _ = g.UnmarshalBinary(b)
 Linux SocketCAN
 - Build tag: enabled automatically on linux (`socketcan_linux.go`).
 - Open a bus with an interface name (e.g., `can0`) using `canbus.DialSocketCAN("can0")`.
+- Optionally configure loopback, own-message echo, and buffer sizes with `DialSocketCANWithOptions`.
 
 ```go
 package main
@@ -115,6 +116,26 @@ func main() {
 
     time.Sleep(2 * time.Second)
 }
+```
+
+SocketCAN options
+```go
+opts := &canbus.SocketCANOptions{}
+
+// Enable local loopback so tools like candump see TX frames (kernel default is on).
+enable := true
+opts.Loopback = &enable
+
+// If you want your own socket to receive its transmitted frames (off by default):
+opts.ReceiveOwnMessages = &enable
+
+// Optionally enlarge buffers
+opts.SendBufferBytes = 1 << 20
+opts.ReceiveBufferBytes = 1 << 20
+
+bus, err := canbus.DialSocketCANWithOptions("can0", opts)
+if err != nil { log.Fatal(err) }
+defer bus.Close()
 ```
 
 Mux and filters

--- a/socketcan_linux.go
+++ b/socketcan_linux.go
@@ -17,14 +17,66 @@ type socketCAN struct {
 	closed chan struct{}
 }
 
-// DialSocketCAN opens a raw CAN socket bound to the given interface name (e.g., "can0").
-func DialSocketCAN(iface string) (Bus, error) {
+// SocketCANOptions configures Linux SocketCAN behavior.
+// All fields are optional; zero value preserves kernel defaults.
+type SocketCANOptions struct {
+	// Loopback controls CAN_RAW_LOOPBACK (see linux/can/raw.h). If nil, default is preserved.
+	Loopback *bool
+	// ReceiveOwnMessages controls CAN_RAW_RECV_OWN_MSGS (echo back to sender). If nil, default preserved.
+	ReceiveOwnMessages *bool
+	// SendBufferBytes sets SO_SNDBUF if > 0.
+	SendBufferBytes int
+	// ReceiveBufferBytes sets SO_RCVBUF if > 0.
+	ReceiveBufferBytes int
+}
+
+// DialSocketCANWithOptions opens a raw CAN socket on iface and applies options.
+func DialSocketCANWithOptions(iface string, opts *SocketCANOptions) (Bus, error) {
 	// Create socket: AF_CAN, SOCK_RAW, CAN_RAW (protocol 1)
 	const AF_CAN = 29
 	const CAN_RAW = 1
 	fd, err := syscall.Socket(AF_CAN, syscall.SOCK_RAW, CAN_RAW)
 	if err != nil {
 		return nil, err
+	}
+	// Apply options before binding.
+	if opts != nil {
+		const SOL_CAN_RAW = 101
+		const CAN_RAW_LOOPBACK = 3
+		const CAN_RAW_RECV_OWN_MSGS = 4
+
+		if opts.Loopback != nil {
+			val := 0
+			if *opts.Loopback {
+				val = 1
+			}
+			if err := syscall.SetsockoptInt(fd, SOL_CAN_RAW, CAN_RAW_LOOPBACK, val); err != nil {
+				syscall.Close(fd)
+				return nil, err
+			}
+		}
+		if opts.ReceiveOwnMessages != nil {
+			val := 0
+			if *opts.ReceiveOwnMessages {
+				val = 1
+			}
+			if err := syscall.SetsockoptInt(fd, SOL_CAN_RAW, CAN_RAW_RECV_OWN_MSGS, val); err != nil {
+				syscall.Close(fd)
+				return nil, err
+			}
+		}
+		if opts.SendBufferBytes > 0 {
+			if err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF, opts.SendBufferBytes); err != nil {
+				syscall.Close(fd)
+				return nil, err
+			}
+		}
+		if opts.ReceiveBufferBytes > 0 {
+			if err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF, opts.ReceiveBufferBytes); err != nil {
+				syscall.Close(fd)
+				return nil, err
+			}
+		}
 	}
 
 	// Query interface index via net.InterfaceByName
@@ -58,6 +110,11 @@ func DialSocketCAN(iface string) (Bus, error) {
 
 	f := os.NewFile(uintptr(fd), "socketcan")
 	return &socketCAN{fd: fd, file: f, closed: make(chan struct{})}, nil
+}
+
+// DialSocketCAN opens a raw CAN socket bound to the given interface name (e.g., "can0").
+func DialSocketCAN(iface string) (Bus, error) {
+	return DialSocketCANWithOptions(iface, nil)
 }
 
 func (s *socketCAN) Close() error {


### PR DESCRIPTION
Add configurable options for Linux SocketCAN to control loopback, own-message echo, and buffer sizes.

The previous `DialSocketCAN` implementation explicitly disabled `CAN_RAW_LOOPBACK` and `CAN_RAW_RECV_OWN_MSGS`, which prevented external tools like `candump` from observing transmitted CAN frames. This PR introduces `SocketCANOptions` and `DialSocketCANWithOptions` to expose these and buffer size settings, allowing users to customize behavior, such as enabling loopback to make TX frames visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7fb8953-a1ae-4f40-8d4a-3684cd001eec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7fb8953-a1ae-4f40-8d4a-3684cd001eec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

