### PR TITLE
Add common bitrate constants for Linux

### DIFF
--- a/iface_linux.go
+++ b/iface_linux.go
@@ -113,6 +113,21 @@ func RequireRootOrCapNetAdmin(err error) error {
 	return err
 }
 
+// Common CAN arbitration bit-rates (bits per second) for Linux interfaces.
+// Use with LinuxCANInterfaceOptions.Bitrate.
+const (
+	CANBitrate10K  uint32 = 10000
+	CANBitrate20K  uint32 = 20000
+	CANBitrate50K  uint32 = 50000
+	CANBitrate83k3 uint32 = 83333
+	CANBitrate100K uint32 = 100000
+	CANBitrate125K uint32 = 125000
+	CANBitrate250K uint32 = 250000
+	CANBitrate500K uint32 = 500000
+	CANBitrate800K uint32 = 800000
+	CANBitrate1M   uint32 = 1000000
+)
+
 // LinuxCANInterfaceOptions controls common CAN interface parameters through the system `ip` tool.
 //
 // Notes:


### PR DESCRIPTION
Add common CAN bitrate constants to `iface_linux.go` to simplify setting `LinuxCANInterfaceOptions.Bitrate`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab1984da-4a42-4194-a005-94a9d7deb135">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab1984da-4a42-4194-a005-94a9d7deb135">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

