### PR TITLE
Update socketcan_linux.go

### DIFF
--- a/socketcan_linux.go
+++ b/socketcan_linux.go
@@ -177,9 +177,3 @@ func (s *socketCAN) Receive() (Frame, error) {
 		return Frame{}, rerr
 	}
 }
-
-// Helpers for FD sets since x/sys is not allowed.
-func fdSetAdd(set *syscall.FdSet, fd int) {
-	set.Bits[fd/64] |= int64(1) << (uint(fd) % 64)
-}
-


### PR DESCRIPTION
Clean up code: removed unused function, which caused a failure during cross build for 32bit architecture.
Bits word width varies by arch (int64 on amd64/arm64, int32 on 386/arm). 

Alternative could be: 
```
func fdSetAdd(set *syscall.FdSet, fd int) {
	const wordBits = 8 * int(unsafe.Sizeof(set.Bits[0]))
	set.Bits[fd/wordBits] |= 1 << uint(fd%wordBits)
}
```

Since the function is never called --> remove
